### PR TITLE
Feature/favorite

### DIFF
--- a/src/main/java/com/ssafy/happyhouse5/constant/BoardConst.java
+++ b/src/main/java/com/ssafy/happyhouse5/constant/BoardConst.java
@@ -1,5 +1,5 @@
 package com.ssafy.happyhouse5.constant;
 
 public interface BoardConst {
-    String BOARD_NOT_FOUND = "not exists board. (by boardId)";
+    String BOARD_NOT_FOUND_MSG = "not exists board. (by boardId)";
 }

--- a/src/main/java/com/ssafy/happyhouse5/constant/FavoriteConst.java
+++ b/src/main/java/com/ssafy/happyhouse5/constant/FavoriteConst.java
@@ -3,4 +3,5 @@ package com.ssafy.happyhouse5.constant;
 public interface FavoriteConst {
 
     String FAVORITE_NOT_FOUND_MSG = "Not exists favorite entity.";
+    String FAVORITE_DUPLICATE_MSG = "Duplicated favorite status.";
 }

--- a/src/main/java/com/ssafy/happyhouse5/constant/FavoriteConst.java
+++ b/src/main/java/com/ssafy/happyhouse5/constant/FavoriteConst.java
@@ -1,0 +1,6 @@
+package com.ssafy.happyhouse5.constant;
+
+public interface FavoriteConst {
+
+    String FAVORITE_NOT_FOUND_MSG = "Not exists favorite entity.";
+}

--- a/src/main/java/com/ssafy/happyhouse5/constant/HouseConst.java
+++ b/src/main/java/com/ssafy/happyhouse5/constant/HouseConst.java
@@ -1,0 +1,6 @@
+package com.ssafy.happyhouse5.constant;
+
+public interface HouseConst {
+
+    String HOUSE_INFO_NOT_FOUND_MSG = "not exists house info.";
+}

--- a/src/main/java/com/ssafy/happyhouse5/controller/restcontroller/HouseRestController.java
+++ b/src/main/java/com/ssafy/happyhouse5/controller/restcontroller/HouseRestController.java
@@ -62,4 +62,11 @@ public class HouseRestController {
                 .toList())
         );
     }
+
+    @GetMapping("/rank")
+    public ResponseEntity<Response> getTopFavoriteRankHouseInfos() {
+        return ResponseEntity.ok(success(
+            houseService.findFavoriteRankHouseInfo(PageRequest.of(0, 10)))
+        );
+    }
 }

--- a/src/main/java/com/ssafy/happyhouse5/controller/restcontroller/MemberRestController.java
+++ b/src/main/java/com/ssafy/happyhouse5/controller/restcontroller/MemberRestController.java
@@ -5,6 +5,7 @@ import static com.ssafy.happyhouse5.dto.common.Response.*;
 import static org.springframework.http.HttpStatus.*;
 
 import com.ssafy.happyhouse5.dto.common.Response;
+import com.ssafy.happyhouse5.dto.favorite.FavoriteRequestDto;
 import com.ssafy.happyhouse5.dto.member.MemberLoginDto;
 import com.ssafy.happyhouse5.dto.member.MemberRegisterDto;
 import com.ssafy.happyhouse5.dto.member.MemberResponseDto;
@@ -118,6 +119,22 @@ public class MemberRestController {
             throw new MemberNotFoundException();
         }
         return ResponseEntity.ok(success(new MemberResponseDto(findMember)));
+    }
+
+    @PostMapping("/favorites")
+    public ResponseEntity<Response> addFavorite(
+        @SessionAttribute(MEMBER_SESSION) Long memberId,
+        @RequestBody FavoriteRequestDto favoriteRequestDto) {
+        Long favoriteId = memberService.enableFavorite(memberId, favoriteRequestDto.getAptCode());
+        return ResponseEntity.ok(success(favoriteId));
+    }
+
+    @DeleteMapping("/favorites")
+    public ResponseEntity<Response> deleteFavorite(
+        @SessionAttribute(MEMBER_SESSION) Long memberId,
+        @RequestBody FavoriteRequestDto favoriteRequestDto) {
+        Long favoriteId = memberService.disableFavorite(memberId, favoriteRequestDto.getAptCode());
+        return ResponseEntity.ok(success(favoriteId));
     }
 
     private void checkHasBindingError(BindingResult bindingResult) {

--- a/src/main/java/com/ssafy/happyhouse5/dto/favorite/FavoriteRequestDto.java
+++ b/src/main/java/com/ssafy/happyhouse5/dto/favorite/FavoriteRequestDto.java
@@ -1,0 +1,11 @@
+package com.ssafy.happyhouse5.dto.favorite;
+
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class FavoriteRequestDto {
+
+    @NotNull
+    private Long aptCode;
+}

--- a/src/main/java/com/ssafy/happyhouse5/dto/house/HouseInfoResponseDto.java
+++ b/src/main/java/com/ssafy/happyhouse5/dto/house/HouseInfoResponseDto.java
@@ -4,6 +4,7 @@ import com.ssafy.happyhouse5.entity.HouseInfo;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.util.StringUtils;
 
 @Getter
 @Setter
@@ -24,7 +25,9 @@ public class HouseInfoResponseDto {
         this.aptCode = houseInfo.getAptCode();
         this.aptName = houseInfo.getAptName();
         this.dongName = houseInfo.getBaseAddress().getDongName();
-        this.buildYear = Integer.parseInt(houseInfo.getBuildYear());
+        if (StringUtils.hasText(houseInfo.getBuildYear())) {
+            this.buildYear = Integer.parseInt(houseInfo.getBuildYear());
+        }
         this.jibun = houseInfo.getJibun();
         this.lat = houseInfo.getLat();
         this.lng = houseInfo.getLng();

--- a/src/main/java/com/ssafy/happyhouse5/dto/house/HouseInfoWithRankDto.java
+++ b/src/main/java/com/ssafy/happyhouse5/dto/house/HouseInfoWithRankDto.java
@@ -1,0 +1,20 @@
+package com.ssafy.happyhouse5.dto.house;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.ssafy.happyhouse5.entity.HouseInfo;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class HouseInfoWithRankDto {
+
+    private HouseInfoResponseDto houseInfoResponseDto;
+    private Long popular;
+
+    @QueryProjection
+    public HouseInfoWithRankDto(HouseInfo houseInfo, Long popular) {
+        this.houseInfoResponseDto = new HouseInfoResponseDto(houseInfo);
+        this.popular = popular;
+    }
+}

--- a/src/main/java/com/ssafy/happyhouse5/entity/BaseAddress.java
+++ b/src/main/java/com/ssafy/happyhouse5/entity/BaseAddress.java
@@ -30,4 +30,8 @@ public class BaseAddress {
 
     @OneToMany(mappedBy = "baseAddress")
     private List<HouseInfo> houseInfos;
+
+    public BaseAddress(String dongName) {
+        this.dongName = dongName;
+    }
 }

--- a/src/main/java/com/ssafy/happyhouse5/entity/Favorite.java
+++ b/src/main/java/com/ssafy/happyhouse5/entity/Favorite.java
@@ -29,4 +29,9 @@ public class Favorite {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "apt_code")
     private HouseInfo houseInfo;
+
+    public Favorite(Member member, HouseInfo houseInfo) {
+        this.member = member;
+        this.houseInfo = houseInfo;
+    }
 }

--- a/src/main/java/com/ssafy/happyhouse5/entity/Favorite.java
+++ b/src/main/java/com/ssafy/happyhouse5/entity/Favorite.java
@@ -9,13 +9,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = PROTECTED)
 public class Favorite {
 
     @Id @GeneratedValue
@@ -30,8 +27,13 @@ public class Favorite {
     @JoinColumn(name = "apt_code")
     private HouseInfo houseInfo;
 
-    public Favorite(Member member, HouseInfo houseInfo) {
+    public void setMember(Member member) {
         this.member = member;
+        member.getFavorites().add(this);
+    }
+
+    public void setHouseInfo(HouseInfo houseInfo){
         this.houseInfo = houseInfo;
+        houseInfo.getFavorites().add(this);
     }
 }

--- a/src/main/java/com/ssafy/happyhouse5/entity/HouseInfo.java
+++ b/src/main/java/com/ssafy/happyhouse5/entity/HouseInfo.java
@@ -32,6 +32,14 @@ public class HouseInfo {
     @JoinColumn(name = "dong_name")
     private BaseAddress baseAddress;
 
+    @BatchSize(size = 200)
+    @OneToMany(mappedBy = "id")
+    @OrderBy("dealYear desc, dealMonth desc, dealDay desc")
+    private final List<HouseDeal> houseDeals = new ArrayList<>();
+
+    @OneToMany(mappedBy = "houseInfo")
+    private final List<Favorite> favorites = new ArrayList<>();
+
     private String buildYear;
 
     private String jibun;
@@ -44,8 +52,4 @@ public class HouseInfo {
 
     private Double avgPrice;
 
-    @BatchSize(size = 200)
-    @OneToMany(mappedBy = "id")
-    @OrderBy("dealYear desc, dealMonth desc, dealDay desc")
-    List<HouseDeal> houseDeals = new ArrayList<>();
 }

--- a/src/main/java/com/ssafy/happyhouse5/entity/HouseInfo.java
+++ b/src/main/java/com/ssafy/happyhouse5/entity/HouseInfo.java
@@ -55,4 +55,9 @@ public class HouseInfo {
     public HouseInfo(String aptName) {
         this.aptName = aptName;
     }
+
+    public HouseInfo(String aptName, BaseAddress baseAddress) {
+        this.aptName = aptName;
+        this.baseAddress = baseAddress;
+    }
 }

--- a/src/main/java/com/ssafy/happyhouse5/entity/HouseInfo.java
+++ b/src/main/java/com/ssafy/happyhouse5/entity/HouseInfo.java
@@ -52,4 +52,7 @@ public class HouseInfo {
 
     private Double avgPrice;
 
+    public HouseInfo(String aptName) {
+        this.aptName = aptName;
+    }
 }

--- a/src/main/java/com/ssafy/happyhouse5/entity/Member.java
+++ b/src/main/java/com/ssafy/happyhouse5/entity/Member.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter
@@ -36,6 +37,7 @@ public class Member {
     @OneToMany(mappedBy = "member")
     private final List<Board> boards = new ArrayList<>();
 
+    @BatchSize(size = 30)
     @OneToMany(mappedBy = "member")
     private final List<Favorite> favorites = new ArrayList<>();
 

--- a/src/main/java/com/ssafy/happyhouse5/entity/Member.java
+++ b/src/main/java/com/ssafy/happyhouse5/entity/Member.java
@@ -35,4 +35,7 @@ public class Member {
 
     @OneToMany(mappedBy = "member")
     private final List<Board> boards = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private final List<Favorite> favorites = new ArrayList<>();
 }

--- a/src/main/java/com/ssafy/happyhouse5/entity/Member.java
+++ b/src/main/java/com/ssafy/happyhouse5/entity/Member.java
@@ -9,6 +9,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,9 +24,11 @@ import org.hibernate.annotations.BatchSize;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"ident"})})
 public class Member {
 
-    @Id @GeneratedValue
+    @Id
+    @GeneratedValue
     @Column(name = "member_id")
     private Long id;
 

--- a/src/main/java/com/ssafy/happyhouse5/entity/Member.java
+++ b/src/main/java/com/ssafy/happyhouse5/entity/Member.java
@@ -38,4 +38,8 @@ public class Member {
 
     @OneToMany(mappedBy = "member")
     private final List<Favorite> favorites = new ArrayList<>();
+
+    public Member(String ident) {
+        this.ident = ident;
+    }
 }

--- a/src/main/java/com/ssafy/happyhouse5/exception/board/BoardNotFoundException.java
+++ b/src/main/java/com/ssafy/happyhouse5/exception/board/BoardNotFoundException.java
@@ -4,11 +4,10 @@ import static com.ssafy.happyhouse5.constant.BoardConst.*;
 import static org.springframework.http.HttpStatus.*;
 
 import com.ssafy.happyhouse5.exception.common.ApplicationException;
-import org.springframework.http.HttpStatus;
 
 public class BoardNotFoundException extends ApplicationException {
 
     public BoardNotFoundException() {
-        super(NOT_FOUND, BOARD_NOT_FOUND);
+        super(NOT_FOUND, BOARD_NOT_FOUND_MSG);
     }
 }

--- a/src/main/java/com/ssafy/happyhouse5/exception/favorite/FavoriteDuplicateException.java
+++ b/src/main/java/com/ssafy/happyhouse5/exception/favorite/FavoriteDuplicateException.java
@@ -1,0 +1,13 @@
+package com.ssafy.happyhouse5.exception.favorite;
+
+import static com.ssafy.happyhouse5.constant.FavoriteConst.*;
+import static org.springframework.http.HttpStatus.*;
+
+import com.ssafy.happyhouse5.exception.common.ApplicationException;
+
+public class FavoriteDuplicateException extends ApplicationException {
+
+    public FavoriteDuplicateException() {
+        super(CONFLICT, FAVORITE_DUPLICATE_MSG);
+    }
+}

--- a/src/main/java/com/ssafy/happyhouse5/exception/favorite/FavoriteNotFoundException.java
+++ b/src/main/java/com/ssafy/happyhouse5/exception/favorite/FavoriteNotFoundException.java
@@ -1,0 +1,13 @@
+package com.ssafy.happyhouse5.exception.favorite;
+
+import static com.ssafy.happyhouse5.constant.FavoriteConst.*;
+import static org.springframework.http.HttpStatus.*;
+
+import com.ssafy.happyhouse5.exception.common.ApplicationException;
+
+public class FavoriteNotFoundException extends ApplicationException {
+
+    public FavoriteNotFoundException() {
+        super(NOT_FOUND, FAVORITE_NOT_FOUND_MSG);
+    }
+}

--- a/src/main/java/com/ssafy/happyhouse5/exception/house/HouseInfoNotFoundException.java
+++ b/src/main/java/com/ssafy/happyhouse5/exception/house/HouseInfoNotFoundException.java
@@ -1,0 +1,13 @@
+package com.ssafy.happyhouse5.exception.house;
+
+import static com.ssafy.happyhouse5.constant.HouseConst.*;
+import static org.springframework.http.HttpStatus.*;
+
+import com.ssafy.happyhouse5.exception.common.ApplicationException;
+
+public class HouseInfoNotFoundException extends ApplicationException {
+
+    public HouseInfoNotFoundException() {
+        super(NOT_FOUND, HOUSE_INFO_NOT_FOUND_MSG);
+    }
+}

--- a/src/main/java/com/ssafy/happyhouse5/exception/member/MemberNotFoundException.java
+++ b/src/main/java/com/ssafy/happyhouse5/exception/member/MemberNotFoundException.java
@@ -1,5 +1,6 @@
 package com.ssafy.happyhouse5.exception.member;
 
+import static com.ssafy.happyhouse5.constant.MemberConst.*;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import com.ssafy.happyhouse5.constant.MemberConst;
@@ -8,6 +9,6 @@ import com.ssafy.happyhouse5.exception.common.ApplicationException;
 public class MemberNotFoundException extends ApplicationException {
 
     public MemberNotFoundException() {
-        super(NOT_FOUND, MemberConst.MEMBER_NOT_FOUND_MSG);
+        super(NOT_FOUND, MEMBER_NOT_FOUND_MSG);
     }
 }

--- a/src/main/java/com/ssafy/happyhouse5/repository/FavoriteRepository.java
+++ b/src/main/java/com/ssafy/happyhouse5/repository/FavoriteRepository.java
@@ -1,0 +1,16 @@
+package com.ssafy.happyhouse5.repository;
+
+import com.ssafy.happyhouse5.entity.Favorite;
+import com.ssafy.happyhouse5.entity.HouseInfo;
+import com.ssafy.happyhouse5.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+    @Query("select f from Favorite f where f.member=:member and f.houseInfo=:houseInfo ")
+    Optional<Favorite> findByMemberAndHouseInfo(
+        @Param("member") Member member, @Param("houseInfo") HouseInfo houseInfo);
+}

--- a/src/main/java/com/ssafy/happyhouse5/repository/FavoriteRepository.java
+++ b/src/main/java/com/ssafy/happyhouse5/repository/FavoriteRepository.java
@@ -3,6 +3,7 @@ package com.ssafy.happyhouse5.repository;
 import com.ssafy.happyhouse5.entity.Favorite;
 import com.ssafy.happyhouse5.entity.HouseInfo;
 import com.ssafy.happyhouse5.entity.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +14,7 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     @Query("select f from Favorite f where f.member=:member and f.houseInfo=:houseInfo ")
     Optional<Favorite> findByMemberAndHouseInfo(
         @Param("member") Member member, @Param("houseInfo") HouseInfo houseInfo);
+
+    @Query("select f From Favorite f join fetch f.houseInfo i where f.member=:member")
+    List<Favorite> findFavoriteByMemberWithHouseInfo(@Param("member") Member member);
 }

--- a/src/main/java/com/ssafy/happyhouse5/repository/HouseInfoCustom.java
+++ b/src/main/java/com/ssafy/happyhouse5/repository/HouseInfoCustom.java
@@ -1,10 +1,14 @@
 package com.ssafy.happyhouse5.repository;
 
+import com.ssafy.happyhouse5.dto.house.HouseInfoWithRankDto;
 import com.ssafy.happyhouse5.dto.locationavg.LocationRange;
 import com.ssafy.happyhouse5.entity.HouseInfo;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 public interface HouseInfoCustom {
 
     List<HouseInfo> findHouseInfoInRange(LocationRange range);
+
+    List<HouseInfoWithRankDto> findRankByFavorite(Pageable pageable);
 }

--- a/src/main/java/com/ssafy/happyhouse5/repository/impl/HouseInfoRepositoryImpl.java
+++ b/src/main/java/com/ssafy/happyhouse5/repository/impl/HouseInfoRepositoryImpl.java
@@ -1,15 +1,19 @@
 package com.ssafy.happyhouse5.repository.impl;
 
+import static com.ssafy.happyhouse5.entity.QFavorite.favorite;
 import static com.ssafy.happyhouse5.entity.QHouseInfo.houseInfo;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ssafy.happyhouse5.dto.house.HouseInfoWithRankDto;
+import com.ssafy.happyhouse5.dto.house.QHouseInfoWithRankDto;
 import com.ssafy.happyhouse5.dto.locationavg.LocationRange;
 import com.ssafy.happyhouse5.entity.HouseInfo;
 import com.ssafy.happyhouse5.repository.HouseInfoCustom;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 
 @RequiredArgsConstructor
 public class HouseInfoRepositoryImpl implements HouseInfoCustom {
@@ -22,6 +26,19 @@ public class HouseInfoRepositoryImpl implements HouseInfoCustom {
             .select(houseInfo)
             .from(houseInfo)
             .where(betweenLatLng(houseInfo.lat, houseInfo.lng, range))
+            .fetch();
+    }
+
+    @Override
+    public List<HouseInfoWithRankDto> findRankByFavorite(Pageable pageable) {
+        return queryFactory
+            .select(new QHouseInfoWithRankDto(houseInfo, houseInfo.count()))
+            .from(favorite)
+            .join(favorite.houseInfo, houseInfo)
+            .groupBy(houseInfo)
+            .orderBy(houseInfo.count().desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
             .fetch();
     }
 

--- a/src/main/java/com/ssafy/happyhouse5/service/HouseService.java
+++ b/src/main/java/com/ssafy/happyhouse5/service/HouseService.java
@@ -1,6 +1,7 @@
 package com.ssafy.happyhouse5.service;
 
 
+import com.ssafy.happyhouse5.dto.house.HouseInfoWithRankDto;
 import com.ssafy.happyhouse5.dto.locationavg.LocationRange;
 import com.ssafy.happyhouse5.entity.HouseDeal;
 import com.ssafy.happyhouse5.entity.HouseInfo;
@@ -17,4 +18,6 @@ public interface HouseService {
     Page<HouseInfo> findHouseInfoByPrefix(String prefix, Pageable pageable);
 
     List<HouseInfo> findHouseInfoInRange(LocationRange range);
+
+    List<HouseInfoWithRankDto> findFavoriteRankHouseInfo(Pageable pageable);
 }

--- a/src/main/java/com/ssafy/happyhouse5/service/MemberService.java
+++ b/src/main/java/com/ssafy/happyhouse5/service/MemberService.java
@@ -3,7 +3,9 @@ package com.ssafy.happyhouse5.service;
 
 import com.ssafy.happyhouse5.dto.member.MemberRegisterDto;
 import com.ssafy.happyhouse5.dto.member.MemberUpdateDto;
+import com.ssafy.happyhouse5.entity.HouseInfo;
 import com.ssafy.happyhouse5.entity.Member;
+import java.util.List;
 
 public interface MemberService {
 
@@ -21,7 +23,9 @@ public interface MemberService {
 
     Member findMemberByEmail(String email);
 
-    void enableFavorite(Long memberId, Long aptCode);
+    Long enableFavorite(Long memberId, Long aptCode);
 
-    void disableFavorite(Long memberId, Long aptCode);
+    Long disableFavorite(Long memberId, Long aptCode);
+
+    List<HouseInfo> getFavoriteHouseInfo(Long memberId);
 }

--- a/src/main/java/com/ssafy/happyhouse5/service/MemberService.java
+++ b/src/main/java/com/ssafy/happyhouse5/service/MemberService.java
@@ -20,4 +20,8 @@ public interface MemberService {
     Member findMemberByIdent(String ident);
 
     Member findMemberByEmail(String email);
+
+    void enableFavorite(Long memberId, Long aptCode);
+
+    void disableFavorite(Long memberId, Long aptCode);
 }

--- a/src/main/java/com/ssafy/happyhouse5/service/impl/HouseServiceImpl.java
+++ b/src/main/java/com/ssafy/happyhouse5/service/impl/HouseServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ssafy.happyhouse5.service.impl;
 
+import com.ssafy.happyhouse5.dto.house.HouseInfoWithRankDto;
 import com.ssafy.happyhouse5.dto.locationavg.LocationRange;
 import com.ssafy.happyhouse5.entity.HouseDeal;
 import com.ssafy.happyhouse5.entity.HouseInfo;
@@ -40,5 +41,10 @@ public class HouseServiceImpl implements HouseService {
     @Override
     public List<HouseInfo> findHouseInfoInRange(LocationRange range) {
         return houseInfoRepository.findHouseInfoInRange(range);
+    }
+
+    @Override
+    public List<HouseInfoWithRankDto> findFavoriteRankHouseInfo(Pageable pageable) {
+        return houseInfoRepository.findRankByFavorite(pageable);
     }
 }

--- a/src/main/java/com/ssafy/happyhouse5/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ssafy/happyhouse5/service/impl/MemberServiceImpl.java
@@ -2,10 +2,12 @@ package com.ssafy.happyhouse5.service.impl;
 
 import com.ssafy.happyhouse5.dto.member.MemberRegisterDto;
 import com.ssafy.happyhouse5.dto.member.MemberUpdateDto;
+import com.ssafy.happyhouse5.entity.HouseInfo;
 import com.ssafy.happyhouse5.entity.Member;
 import com.ssafy.happyhouse5.exception.member.MemberNotFoundException;
 import com.ssafy.happyhouse5.repository.MemberRepository;
 import com.ssafy.happyhouse5.service.MemberService;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -70,12 +72,17 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public void enableFavorite(Long memberId, Long aptCode) {
-
+    public Long enableFavorite(Long memberId, Long aptCode) {
+        return 0L;
     }
 
     @Override
-    public void disableFavorite(Long memberId, Long aptCode) {
+    public Long disableFavorite(Long memberId, Long aptCode) {
+        return 0L;
+    }
 
+    @Override
+    public List<HouseInfo> getFavoriteHouseInfo(Long memberId) {
+        return null;
     }
 }

--- a/src/main/java/com/ssafy/happyhouse5/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ssafy/happyhouse5/service/impl/MemberServiceImpl.java
@@ -5,6 +5,7 @@ import com.ssafy.happyhouse5.dto.member.MemberUpdateDto;
 import com.ssafy.happyhouse5.entity.Favorite;
 import com.ssafy.happyhouse5.entity.HouseInfo;
 import com.ssafy.happyhouse5.entity.Member;
+import com.ssafy.happyhouse5.exception.favorite.FavoriteDuplicateException;
 import com.ssafy.happyhouse5.exception.favorite.FavoriteNotFoundException;
 import com.ssafy.happyhouse5.exception.house.HouseInfoNotFoundException;
 import com.ssafy.happyhouse5.exception.member.MemberNotFoundException;
@@ -80,6 +81,10 @@ public class MemberServiceImpl implements MemberService {
     public Long enableFavorite(Long memberId, Long aptCode) {
         Member member = checkExistAndGetMember(memberRepository.findById(memberId));
         HouseInfo houseInfo = checkExistAndGetHouseInfoByAptCode(aptCode);
+        if(favoriteRepository.findByMemberAndHouseInfo(member, houseInfo)
+            .isPresent()){
+            throw new FavoriteDuplicateException();
+        }
 
         return favoriteRepository.save(new Favorite(member, houseInfo)).getId();
     }

--- a/src/main/java/com/ssafy/happyhouse5/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ssafy/happyhouse5/service/impl/MemberServiceImpl.java
@@ -15,6 +15,7 @@ import com.ssafy.happyhouse5.repository.MemberRepository;
 import com.ssafy.happyhouse5.service.MemberService;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,7 +87,10 @@ public class MemberServiceImpl implements MemberService {
             throw new FavoriteDuplicateException();
         }
 
-        return favoriteRepository.save(new Favorite(member, houseInfo)).getId();
+        Favorite favorite = new Favorite();
+        favorite.setMember(member);
+        favorite.setHouseInfo(houseInfo);
+        return favoriteRepository.save(favorite).getId();
     }
 
     @Override
@@ -101,7 +105,10 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public List<HouseInfo> getFavoriteHouseInfo(Long memberId) {
-        return null;
+        Member member = checkExistAndGetMember(memberRepository.findById(memberId));
+        return favoriteRepository.findFavoriteByMemberWithHouseInfo(member).stream()
+            .map(Favorite::getHouseInfo)
+            .collect(Collectors.toList());
     }
 
     private Member checkExistAndGetMember(Optional<Member> optional) {

--- a/src/main/java/com/ssafy/happyhouse5/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ssafy/happyhouse5/service/impl/MemberServiceImpl.java
@@ -2,9 +2,14 @@ package com.ssafy.happyhouse5.service.impl;
 
 import com.ssafy.happyhouse5.dto.member.MemberRegisterDto;
 import com.ssafy.happyhouse5.dto.member.MemberUpdateDto;
+import com.ssafy.happyhouse5.entity.Favorite;
 import com.ssafy.happyhouse5.entity.HouseInfo;
 import com.ssafy.happyhouse5.entity.Member;
+import com.ssafy.happyhouse5.exception.favorite.FavoriteNotFoundException;
+import com.ssafy.happyhouse5.exception.house.HouseInfoNotFoundException;
 import com.ssafy.happyhouse5.exception.member.MemberNotFoundException;
+import com.ssafy.happyhouse5.repository.FavoriteRepository;
+import com.ssafy.happyhouse5.repository.HouseInfoRepository;
 import com.ssafy.happyhouse5.repository.MemberRepository;
 import com.ssafy.happyhouse5.service.MemberService;
 import java.util.List;
@@ -19,6 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
+
+    private final FavoriteRepository favoriteRepository;
+
+    private final HouseInfoRepository houseInfoRepository;
 
     @Override
     @Transactional
@@ -67,22 +76,35 @@ public class MemberServiceImpl implements MemberService {
         return checkExistAndGetMember(memberRepository.findMemberByEmail(email));
     }
 
-    private Member checkExistAndGetMember(Optional<Member> memberRepository) {
-        return memberRepository.orElseThrow(MemberNotFoundException::new);
-    }
-
     @Override
     public Long enableFavorite(Long memberId, Long aptCode) {
-        return 0L;
+        Member member = checkExistAndGetMember(memberRepository.findById(memberId));
+        HouseInfo houseInfo = checkExistAndGetHouseInfoByAptCode(aptCode);
+
+        return favoriteRepository.save(new Favorite(member, houseInfo)).getId();
     }
 
     @Override
     public Long disableFavorite(Long memberId, Long aptCode) {
-        return 0L;
+        Member member = checkExistAndGetMember(memberRepository.findById(memberId));
+        HouseInfo houseInfo = checkExistAndGetHouseInfoByAptCode(aptCode);
+        Favorite favorite = favoriteRepository.findByMemberAndHouseInfo(member, houseInfo)
+            .orElseThrow(FavoriteNotFoundException::new);
+        favoriteRepository.delete(favorite);
+        return favorite.getId();
     }
 
     @Override
     public List<HouseInfo> getFavoriteHouseInfo(Long memberId) {
         return null;
+    }
+
+    private Member checkExistAndGetMember(Optional<Member> optional) {
+        return optional.orElseThrow(MemberNotFoundException::new);
+    }
+
+    private HouseInfo checkExistAndGetHouseInfoByAptCode(Long aptCode) {
+        return houseInfoRepository.findById(aptCode)
+            .orElseThrow(HouseInfoNotFoundException::new);
     }
 }

--- a/src/main/java/com/ssafy/happyhouse5/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ssafy/happyhouse5/service/impl/MemberServiceImpl.java
@@ -79,6 +79,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional
     public Long enableFavorite(Long memberId, Long aptCode) {
         Member member = checkExistAndGetMember(memberRepository.findById(memberId));
         HouseInfo houseInfo = checkExistAndGetHouseInfoByAptCode(aptCode);
@@ -94,6 +95,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional
     public Long disableFavorite(Long memberId, Long aptCode) {
         Member member = checkExistAndGetMember(memberRepository.findById(memberId));
         HouseInfo houseInfo = checkExistAndGetHouseInfoByAptCode(aptCode);

--- a/src/main/java/com/ssafy/happyhouse5/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/ssafy/happyhouse5/service/impl/MemberServiceImpl.java
@@ -68,4 +68,14 @@ public class MemberServiceImpl implements MemberService {
     private Member checkExistAndGetMember(Optional<Member> memberRepository) {
         return memberRepository.orElseThrow(MemberNotFoundException::new);
     }
+
+    @Override
+    public void enableFavorite(Long memberId, Long aptCode) {
+
+    }
+
+    @Override
+    public void disableFavorite(Long memberId, Long aptCode) {
+
+    }
 }

--- a/src/test/java/com/ssafy/happyhouse5/service/HouseServiceTest.java
+++ b/src/test/java/com/ssafy/happyhouse5/service/HouseServiceTest.java
@@ -1,0 +1,97 @@
+package com.ssafy.happyhouse5.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ssafy.happyhouse5.dto.house.HouseInfoWithRankDto;
+import com.ssafy.happyhouse5.entity.BaseAddress;
+import com.ssafy.happyhouse5.entity.Favorite;
+import com.ssafy.happyhouse5.entity.HouseInfo;
+import com.ssafy.happyhouse5.entity.Member;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class HouseServiceTest {
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Autowired
+    HouseService houseService;
+
+    @Autowired
+    JPAQueryFactory queryFactory;
+
+    @Test
+    @DisplayName("Favorite 에 저장된 즐겨찾기 순위에 따른 HouseInfoWithRankDto: {HouseInfo + Count} 반환 테스트")
+    void favoriteRankHouseInfoTest(){
+        Member member1 = new Member("member1");
+        Member member2 = new Member("member2");
+        Member member3 = new Member("member3");
+
+        BaseAddress baseAddress = new BaseAddress("dong_temp");
+
+        HouseInfo houseInfo1 = new HouseInfo("apt1", baseAddress);
+        HouseInfo houseInfo2 = new HouseInfo("apt2", baseAddress);
+        HouseInfo houseInfo3 = new HouseInfo("apt3", baseAddress);
+
+        em.persist(member1);
+        em.persist(member2);
+        em.persist(member3);
+
+        em.persist(baseAddress);
+
+        em.persist(houseInfo1);
+        em.persist(houseInfo2);
+        em.persist(houseInfo3);
+
+        Favorite favorite1 = new Favorite();
+        favorite1.setMember(member1);
+        favorite1.setHouseInfo(houseInfo1);
+
+        Favorite favorite2 = new Favorite();
+        favorite2.setMember(member1);
+        favorite2.setHouseInfo(houseInfo2);
+
+        Favorite favorite3 = new Favorite();
+        favorite3.setMember(member1);
+        favorite3.setHouseInfo(houseInfo3);
+
+        Favorite favorite4 = new Favorite();
+        favorite4.setMember(member2);
+        favorite4.setHouseInfo(houseInfo1);
+
+        Favorite favorite5 = new Favorite();
+        favorite5.setMember(member2);
+        favorite5.setHouseInfo(houseInfo2);
+
+        Favorite favorite6 = new Favorite();
+        favorite6.setMember(member3);
+        favorite6.setHouseInfo(houseInfo1);
+
+        em.persist(favorite1);
+        em.persist(favorite2);
+        em.persist(favorite3);
+        em.persist(favorite4);
+        em.persist(favorite5);
+        em.persist(favorite6);
+
+        Pageable pageable = PageRequest.of(0, 3);
+        List<HouseInfoWithRankDto> houseInfos = houseService.findFavoriteRankHouseInfo(pageable);
+
+        assertThat(houseInfos)
+            .extracting("houseInfoResponseDto")
+            .extracting("aptName")
+            .containsExactly("apt1", "apt2", "apt3");
+    }
+}

--- a/src/test/java/com/ssafy/happyhouse5/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/happyhouse5/service/MemberServiceTest.java
@@ -11,6 +11,7 @@ import com.ssafy.happyhouse5.exception.favorite.FavoriteDuplicateException;
 import com.ssafy.happyhouse5.exception.favorite.FavoriteNotFoundException;
 import com.ssafy.happyhouse5.exception.house.HouseInfoNotFoundException;
 import com.ssafy.happyhouse5.exception.member.MemberNotFoundException;
+import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -192,5 +193,23 @@ class MemberServiceTest {
         memberService.enableFavorite(member.getId(), houseInfo.getAptCode());
         assertThrows(FavoriteDuplicateException.class,
             () -> memberService.enableFavorite(member.getId(), houseInfo.getAptCode()));
+    }
+
+    @Test
+    @DisplayName("즐겨찾기로 등록된 HouseInfo 조회 테스트")
+    void findHouseInfoByMember() {
+        Member member = new Member("member1");
+        HouseInfo houseInfo1 = new HouseInfo("apt1");
+        HouseInfo houseInfo2 = new HouseInfo("apt2");
+
+        em.persist(member);
+        em.persist(houseInfo1);
+        em.persist(houseInfo2);
+
+        memberService.enableFavorite(member.getId(), houseInfo1.getAptCode());
+        memberService.enableFavorite(member.getId(), houseInfo2.getAptCode());
+
+        List<HouseInfo> favoriteHouseInfos = memberService.getFavoriteHouseInfo(member.getId());
+        assertThat(favoriteHouseInfos).contains(houseInfo1, houseInfo2);
     }
 }

--- a/src/test/java/com/ssafy/happyhouse5/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/happyhouse5/service/MemberServiceTest.java
@@ -1,13 +1,14 @@
 package com.ssafy.happyhouse5.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.ssafy.happyhouse5.dto.member.MemberUpdateDto;
+import com.ssafy.happyhouse5.entity.Favorite;
+import com.ssafy.happyhouse5.entity.HouseInfo;
 import com.ssafy.happyhouse5.entity.Member;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -105,5 +106,21 @@ class MemberServiceTest {
         assertThat(memberService.findMemberByEmail(MEMBER_EMAIL)).isNotNull();
         assertThrows(RuntimeException.class,
             () -> memberService.findMemberByEmail(MEMBER_EMAIL + GARBAGE_VALUE));
+    }
+
+    @Test
+    @DisplayName("즐겨찾기 등록 테스트")
+    void createFavoriteTest() {
+        Member member = new Member("member1");
+        HouseInfo houseInfo = new HouseInfo("apt1");
+
+        em.persist(member);
+        em.persist(houseInfo);
+
+        Long favoriteId = memberService.enableFavorite(member.getId(), houseInfo.getAptCode());
+        Favorite favorite = em.find(Favorite.class, favoriteId);
+        assertThat(favorite).isNotNull();
+        assertThat(favorite.getMember()).isEqualTo(member);
+        assertThat(favorite.getHouseInfo()).isEqualTo(houseInfo);
     }
 }

--- a/src/test/java/com/ssafy/happyhouse5/service/MemberServiceTest.java
+++ b/src/test/java/com/ssafy/happyhouse5/service/MemberServiceTest.java
@@ -7,6 +7,7 @@ import com.ssafy.happyhouse5.dto.member.MemberUpdateDto;
 import com.ssafy.happyhouse5.entity.Favorite;
 import com.ssafy.happyhouse5.entity.HouseInfo;
 import com.ssafy.happyhouse5.entity.Member;
+import com.ssafy.happyhouse5.exception.favorite.FavoriteDuplicateException;
 import com.ssafy.happyhouse5.exception.favorite.FavoriteNotFoundException;
 import com.ssafy.happyhouse5.exception.house.HouseInfoNotFoundException;
 import com.ssafy.happyhouse5.exception.member.MemberNotFoundException;
@@ -58,12 +59,12 @@ class MemberServiceTest {
     void login() {
         assertThat(memberService.login(MEMBER_ID, MEMBER_PASSWORD))
             .isEqualTo(true);
-//        assertThat(memberService.login(MEMBER_ID + GARBAGE_VALUE, MEMBER_PASSWORD + GARBAGE_VALUE))
-//            .isEqualTo(false);
-//        assertThat(memberService.login(MEMBER_ID, MEMBER_PASSWORD + GARBAGE_VALUE))
-//            .isEqualTo(false);
-//        assertThat(memberService.login(MEMBER_ID + GARBAGE_VALUE, MEMBER_PASSWORD))
-//            .isEqualTo(false);
+        assertThrows(MemberNotFoundException.class,
+            () -> memberService.login(MEMBER_ID + GARBAGE_VALUE, MEMBER_PASSWORD + GARBAGE_VALUE));
+        assertThrows(MemberNotFoundException.class,
+            () -> memberService.login(MEMBER_ID + GARBAGE_VALUE, MEMBER_PASSWORD));
+        assertThat(memberService.login(MEMBER_ID, MEMBER_PASSWORD + GARBAGE_VALUE))
+            .isEqualTo(false);
     }
 
     @Test
@@ -177,5 +178,19 @@ class MemberServiceTest {
 
         assertThrows(FavoriteNotFoundException.class,
             () -> memberService.disableFavorite(member.getId(), houseInfo.getAptCode()));
+    }
+
+    @Test
+    @DisplayName("즐겨찾기 중복 등록 테스트")
+    void duplicateFavoriteTest() {
+        Member member = new Member("member1");
+        HouseInfo houseInfo = new HouseInfo("apt1");
+
+        em.persist(member);
+        em.persist(houseInfo);
+
+        memberService.enableFavorite(member.getId(), houseInfo.getAptCode());
+        assertThrows(FavoriteDuplicateException.class,
+            () -> memberService.enableFavorite(member.getId(), houseInfo.getAptCode()));
     }
 }


### PR DESCRIPTION
Favorite: 즐겨찾기 엔티티 관련 기능 추가.

사용자 ID, HOUSE_INFO ID 를 foreign key 로 갖도록 엔티티 구성.

추가/삭제에 대해 예외 처리와 컨트롤러, 서비스, jpa + query dsl로 작성.

HOUSE_INFO 를 Favorite 테이블에 있는 가장 많은 아파트를 순위를 메겨 제공하도록 구현. (querydsl)